### PR TITLE
Update parseNextConfiguration to get next server config from new path

### DIFF
--- a/lib/parseNextConfiguration.js
+++ b/lib/parseNextConfiguration.js
@@ -1,9 +1,21 @@
-const nextLoadConfig = require("next-server/dist/server/config").default;
-const { PHASE_PRODUCTION_BUILD } = require("next-server/dist/lib/constants");
+let nextLoadConfig;
+let PHASE_PRODUCTION_BUILD;
+try {
+  nextLoadConfig = require("next-server/dist/server/config").default;
+  PHASE_PRODUCTION_BUILD = require("next-server/dist/lib/constants")
+    .PHASE_PRODUCTION_BUILD;
+} catch (e) {
+  // https://github.com/danielcondemarin/serverless-next.js/issues/157
+  // Some files were moved in the dist/ directory in next.js 9.0.6
+  // check the new location if the old location failed.
+  nextLoadConfig = require("next/dist/next-server/server/config").default;
+  PHASE_PRODUCTION_BUILD = require("next/dist/next-server/lib/constants")
+    .PHASE_PRODUCTION_BUILD;
+}
 const s3Urls = require("@mapbox/s3urls");
 const createError = require("../utils/createError");
 
-module.exports = nextConfigDir => {
+module.exports = (nextConfigDir) => {
   if (typeof nextConfigDir !== "string") {
     throw createError("Provide a valid next.config file path");
   }
@@ -26,6 +38,6 @@ module.exports = nextConfigDir => {
 
   return {
     staticAssetsBucket,
-    nextConfiguration
+    nextConfiguration,
   };
 };


### PR DESCRIPTION
https://github.com/danielcondemarin/serverless-next.js/issues/157
Some files were moved in the dist/ directory in next.js 9.0.6
check the new location if the old location failed.