### PR TITLE
Build errors fixes

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -45,7 +45,8 @@ module.exports = async function() {
     `!${path.posix.join(nextAwsLambdaPath, "**", "*.test.js")}`
   );
 
-  const { nextConfiguration } = await parseNextConfiguration(nextConfigDir);
+  const configs = parseNextConfiguration(nextConfigDir);
+  const nextConfiguration = await configs.nextConfiguration;
 
   overrideTargetIfNotServerless(nextConfiguration);
 
@@ -72,7 +73,10 @@ module.exports = async function() {
 
   if (omitErrorPage) {
     console.log("Omitting _error page");
-    nextPages = nextPages.filter(page => page.pageName != "_error");
+    nextPages = nextPages.filter(
+      (page) =>
+        page.pageName != "_error" && page.pageId != 500 && page.pageId != 404
+    );
   }
 
   await rewritePageHandlers(nextPages, customHandler);


### PR DESCRIPTION
Errors fixed (see below) 
**1.**
```
  TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
      at validateString (internal/validators.js:121:11)
      at Object.join (path.js:1039:7)
      at ServerlessNextJsPlugin.module.exports (~/customer-vehicle-host-app/node_modules/serverless-nextjs-plugin/lib/build.js:57:10)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at ServerlessNextJsPlugin.hookWrapper (~/customer-vehicle-host-app/node_modules/serverless-nextjs-plugin/index.js:54:12)
      at PluginManager.invoke (~/customer-vehicle-host-app/node_modules/serverless/lib/classes/PluginManager.js:544:9)
      at PluginManager.spawn (~/customer-vehicle-host-app/node_modules/serverless/lib/classes/PluginManager.js:566:5)
      at Object.before:deploy:deploy [as hook] (~/customer-vehicle-host-app/node_modules/serverless/lib/plugins/deploy.js:65:13)
      at PluginManager.invoke (~/customer-vehicle-host-app/node_modules/serverless/lib/classes/PluginManager.js:544:9)
```
**2.**

`  An error occurred: ApiGatewayResource500html - Another resource with the same parent already has this name: 500.html (Service: AmazonApiGateway; Status Code: 409; Error Code: ConflictException; Request ID: 35d9f9f6-3e35-4157-83ea-17a10bb861a4; Proxy: null).`