### PR TITLE
Allow next 11 integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "@Cazoo-uk/serverless-nextjs-plugin",
   "license": "MIT",
   "peerDependencies": {
-    "next": "^8.0.0 || ^9.0.0 || ^10.0.0"
+    "next": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The branching/versioning in this project is a bit weird (and admittedly, it's my own fault). I will tackle that, so ignore the branch name here. I want to get the content app onto next 11. I'm pretty sure this should be compatible because it still supports initial props.